### PR TITLE
接頭辞に角括弧が半角のパターン，接尾辞のプラスが全角のパターンも除去できる.

### DIFF
--- a/deremas_data/spiders/deremas_spider.py
+++ b/deremas_data/spiders/deremas_spider.py
@@ -6,7 +6,7 @@ from scrapy import Spider
 import deremas_data.spiders.extract_util as util
 
 
-exclude_card_names = {'（アイドル名）'}
+EXCLUDE_CARD_NAMES = {'（アイドル名）'}
 
 
 class DeremasSpider(Spider):
@@ -32,7 +32,7 @@ class DeremasSpider(Spider):
         line_block_ids = util.search_block_id(response, 'セリフ集')
         if profile_block_ids and line_block_ids:
             card_name = util.extract_card_name(response)
-            if card_name not in exclude_card_names:
+            if card_name not in EXCLUDE_CARD_NAMES:
                 idol_name = util.extract_idol_name(card_name)
                 type_name = util.extract_type(response)
                 yield {

--- a/deremas_data/spiders/extract_util.py
+++ b/deremas_data/spiders/extract_util.py
@@ -51,7 +51,11 @@ def extract_idol_name(card_name):
     :param card_name: カードの名前
     :return: アイドルの名前
     """
-    return sub(r'\+$', '', sub(r'^［.+?］', '', card_name))
+    return sub(
+                r'\s*?[\+＋]$',
+                '',
+                sub(r'^\s*?[\[［].+?[］\]]\s*?', '', card_name)
+            )
 
 
 def extract_type(response, data_block_id=None):


### PR DESCRIPTION
カード名の接頭辞に半角角括弧が使われていたり,
接尾辞のプラスに全角プラスが使われていたりした場合も
正しくアイドル名のみ抽出できるようにするため正規表現を修正した